### PR TITLE
Adding the LineBreak element from xaml

### DIFF
--- a/MarkupConverter/htmlfromxamlconverter.cs
+++ b/MarkupConverter/htmlfromxamlconverter.cs
@@ -246,9 +246,6 @@ namespace MarkupConverter
                     case "TargetName":
                         htmlWriter.WriteAttributeString("TARGET", xamlReader.Value);
                         break;
-				
-		    case "linebreak":
-			htmlWriter.WriteAttributeString("BR", xamlReader.Value);
                 }
 
                 if (css != null)
@@ -504,6 +501,9 @@ namespace MarkupConverter
                         break;
                     case "Hyperlink":
                         htmlElementName = "A";
+                        break;
+                    case "LineBreak":
+                        htmlElementName = "BR";
                         break;
                     default :
                         htmlElementName = null; // Ignore the element

--- a/MarkupConverter/htmlfromxamlconverter.cs
+++ b/MarkupConverter/htmlfromxamlconverter.cs
@@ -246,6 +246,9 @@ namespace MarkupConverter
                     case "TargetName":
                         htmlWriter.WriteAttributeString("TARGET", xamlReader.Value);
                         break;
+				
+		    case "linebreak":
+			htmlWriter.WriteAttributeString("BR", xamlReader.Value);
                 }
 
                 if (css != null)


### PR DESCRIPTION
This PR added a new element from xaml to be implemented :
A "ctrl+enter" command will create a LineBreak element and is not take in count by the Converter.